### PR TITLE
Navbar Bug Fixed!

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -35,14 +35,14 @@ body {
     overflow-x: hidden;
 }
 p {
-    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     font-size: 16px;
     font-weight: 400;
     color: inherit;
     line-height: 24px;
 }
 h1 {
-    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     font-weight: 700;
 }
 .center {

--- a/css/style.css
+++ b/css/style.css
@@ -1,9 +1,11 @@
 .fixed-top.scrolled {
     background-color: #222324 !important;
-    transition: background-color 500ms linear;
 }
 .text-white.dark {
     color: #222324 !important;
+}
+.fixed-top {
+    transition: background-color 500ms linear;
 }
 .main-sponsor {
     max-height: 12vh;
@@ -27,19 +29,20 @@
     padding-left: 25px;
     padding-right: 25px;
 }
-html, body {
+html,
+body {
     width: 100%;
     overflow-x: hidden;
 }
 p {
-    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     font-size: 16px;
     font-weight: 400;
     color: inherit;
     line-height: 24px;
 }
 h1 {
-    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     font-weight: 700;
 }
 .center {
@@ -47,14 +50,14 @@ h1 {
     justify-content: center;
     flex-direction: column;
 }
-.googleCalendar{
+.googleCalendar {
     position: relative;
     height: 0;
     width: 99%;
     padding-bottom: 99%;
 }
 
-.googleCalendar iframe{
+.googleCalendar iframe {
     position: absolute;
     top: 0;
     left: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -1,66 +1,71 @@
 .fixed-top.scrolled {
-    background-color: #222324 !important;
-    transition: background-color 500ms linear;
+  background-color: #222324 !important;
 }
 .text-white.dark {
-    color: #222324 !important;
+  color: #222324 !important;
+}
+.fixed-top {
+  transition: background-color 500ms linear;
 }
 .main-sponsor {
-    max-height: 12vh;
-    max-width: 50vw;
-    margin-top: 25px;
-    margin-bottom: 25px;
+  max-height: 12vh;
+  max-width: 50vw;
+  margin-top: 25px;
+  margin-bottom: 25px;
 }
 .sponsor {
-    max-height: 10vh;
-    margin-top: 25px;
-    margin-bottom: 25px;
+  max-height: 10vh;
+  margin-top: 25px;
+  margin-bottom: 25px;
 }
 .row-footer {
-    padding: 20px 0;
-    background-color: #222324;
-    color: white;
+  padding: 20px 0;
+  background-color: #222324;
+  color: white;
 }
 .heading {
-    margin-top: 50px;
-    margin-bottom: 50px;
-    padding-left: 25px;
-    padding-right: 25px;
+  margin-top: 50px;
+  margin-bottom: 50px;
+  padding-left: 25px;
+  padding-right: 25px;
 }
-html, body {
-    width: 100%;
-    overflow-x: hidden;
+html,
+body {
+  width: 100%;
+  overflow-x: hidden;
 }
 p {
-    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    font-size: 16px;
-    font-weight: 400;
-    color: inherit;
-    line-height: 24px;
+  font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  color: inherit;
+  line-height: 24px;
 }
 h1 {
-    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    font-weight: 700;
+  font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-weight: 700;
 }
 .center {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
 }
-.googleCalendar{
-    position: relative;
-    height: 0;
-    width: 99%;
-    padding-bottom: 99%;
+.googleCalendar {
+  position: relative;
+  height: 0;
+  width: 99%;
+  padding-bottom: 99%;
 }
 
-.googleCalendar iframe{
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+.googleCalendar iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 li a {
-    color: white;
+  color: white;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -29,20 +29,19 @@
     padding-left: 25px;
     padding-right: 25px;
 }
-html,
-body {
+html, body {
     width: 100%;
     overflow-x: hidden;
 }
 p {
-    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     font-size: 16px;
     font-weight: 400;
     color: inherit;
     line-height: 24px;
 }
 h1 {
-    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     font-weight: 700;
 }
 .center {

--- a/css/style.css
+++ b/css/style.css
@@ -1,71 +1,69 @@
 .fixed-top.scrolled {
-  background-color: #222324 !important;
+    background-color: #222324 !important;
 }
 .text-white.dark {
-  color: #222324 !important;
+    color: #222324 !important;
 }
 .fixed-top {
-  transition: background-color 500ms linear;
+    transition: background-color 500ms linear;
 }
 .main-sponsor {
-  max-height: 12vh;
-  max-width: 50vw;
-  margin-top: 25px;
-  margin-bottom: 25px;
+    max-height: 12vh;
+    max-width: 50vw;
+    margin-top: 25px;
+    margin-bottom: 25px;
 }
 .sponsor {
-  max-height: 10vh;
-  margin-top: 25px;
-  margin-bottom: 25px;
+    max-height: 10vh;
+    margin-top: 25px;
+    margin-bottom: 25px;
 }
 .row-footer {
-  padding: 20px 0;
-  background-color: #222324;
-  color: white;
+    padding: 20px 0;
+    background-color: #222324;
+    color: white;
 }
 .heading {
-  margin-top: 50px;
-  margin-bottom: 50px;
-  padding-left: 25px;
-  padding-right: 25px;
+    margin-top: 50px;
+    margin-bottom: 50px;
+    padding-left: 25px;
+    padding-right: 25px;
 }
 html,
 body {
-  width: 100%;
-  overflow-x: hidden;
+    width: 100%;
+    overflow-x: hidden;
 }
 p {
-  font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  color: inherit;
-  line-height: 24px;
+    font-family: Inter, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    color: inherit;
+    line-height: 24px;
 }
 h1 {
-  font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  font-weight: 700;
+    font-family: Castledown, -apple-system, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-weight: 700;
 }
 .center {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
 }
 .googleCalendar {
-  position: relative;
-  height: 0;
-  width: 99%;
-  padding-bottom: 99%;
+    position: relative;
+    height: 0;
+    width: 99%;
+    padding-bottom: 99%;
 }
 
 .googleCalendar iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 li a {
-  color: white;
+    color: white;
 }

--- a/index_mobile.html
+++ b/index_mobile.html
@@ -41,11 +41,11 @@
 
 <!--========== HEADER ==========-->
 <!-- Start Navbar -->
-<nav class="navbar fixed-top navbar-expand-lg">
+<nav id="nav-bar" class="navbar fixed-top navbar-expand-lg">
     <!-- Brand/logo -->
     <a class="navbar-brand" href="#"><img src="img/logos/hacksoc-logo-custom.png" width="100vw"/></a>
 
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" id="toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <i class="fas fa-bars" style="color:white"></i>
     </button>
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,8 +1,16 @@
-$(function () {
-    $(document).scroll(function () {
-        var $nav = $(".fixed-top");
-        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height());
-        var $text = $(".text-white");
+$(function() {
+    $(document).scroll(function() {
+        var $nav = $('.fixed-top')
+        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height())
+        var $text = $('.text-white')
         $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
-    });
-});
+    })
+    $('.navbar-toggler').click(() => {
+        var $nav = $('.fixed-top')
+        var $text = $('.text-white')
+        if ($(this).scrollTop() < $nav.height()) {
+            $nav.toggleClass('scrolled')
+            $text.toggleClass('dark')
+        }
+    })
+})

--- a/js/script.js
+++ b/js/script.js
@@ -1,16 +1,16 @@
 $(function() {
     $(document).scroll(function() {
-        var $nav = $('.fixed-top')
-        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height())
-        var $text = $('.text-white')
-        $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
-    })
-    $('.navbar-toggler').click(() => {
-        var $nav = $('.fixed-top')
-        var $text = $('.text-white')
+        var $nav = $(".fixed-top");
+        $nav.toggleClass("scrolled", $(this).scrollTop() > $nav.height());
+        var $text = $(".text-white");
+        $text.toggleClass("dark", $(this).scrollTop() > $nav.height());
+    });
+    $(".navbar-toggler").click(() => {
+        var $nav = $(".fixed-top");
+        var $text = $(".text-white");
         if ($(this).scrollTop() < $nav.height()) {
-            $nav.toggleClass('scrolled')
-            $text.toggleClass('dark')
+            $nav.toggleClass("scrolled");
+            $text.toggleClass("dark");
         }
-    })
-})
+    });
+});

--- a/js/script.js
+++ b/js/script.js
@@ -1,8 +1,16 @@
-$(function () {
-    $(document).scroll(function () {
-        var $nav = $(".fixed-top");
-        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height());
-        var $text = $(".text-white");
-        $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
-    });
-});
+$(function() {
+  $(document).scroll(function() {
+    var $nav = $('.fixed-top')
+    $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height())
+    var $text = $('.text-white')
+    $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
+  })
+  $('.navbar-toggler').click(() => {
+    var $nav = $('.fixed-top')
+    var $text = $('.text-white')
+    if ($(this).scrollTop() < $nav.height()) {
+      $nav.toggleClass('scrolled')
+      $text.toggleClass('dark')
+    }
+  })
+})

--- a/js/script.js
+++ b/js/script.js
@@ -1,16 +1,15 @@
 $(function() {
     $(document).scroll(function() {
-        var $nav = $('.fixed-top')
-        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height())
-        var $text = $('.text-white')
-        $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
+        var $nav = $("#nav-bar")
+        var $navSupportedContent = $("#navbarSupportedContent")
+        var isShown = $navSupportedContent.attr("class").includes(" show")
+        if(!isShown)
+            $nav.toggleClass("scrolled", $(this).scrollTop() > $nav.height())
     })
-    $('.navbar-toggler').click(() => {
-        var $nav = $('.fixed-top')
-        var $text = $('.text-white')
+    $("#toggler").click(() => {
+        var $nav = $("#nav-bar")
         if ($(this).scrollTop() < $nav.height()) {
-            $nav.toggleClass('scrolled')
-            $text.toggleClass('dark')
+            $nav.toggleClass("scrolled")
         }
     })
 })

--- a/js/script.js
+++ b/js/script.js
@@ -1,16 +1,16 @@
 $(function() {
-    $(document).scroll(function() {
-        var $nav = $(".fixed-top");
-        $nav.toggleClass("scrolled", $(this).scrollTop() > $nav.height());
-        var $text = $(".text-white");
-        $text.toggleClass("dark", $(this).scrollTop() > $nav.height());
+    $(document).scroll(function () {
+        var $nav = $('.fixed-top');
+        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height());
+        var $text = $('.text-white');
+        $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
     });
-    $(".navbar-toggler").click(() => {
-        var $nav = $(".fixed-top");
-        var $text = $(".text-white");
+    $('.navbar-toggler').click(() => {
+        var $nav = $('.fixed-top');
+        var $text = $('.text-white');
         if ($(this).scrollTop() < $nav.height()) {
-            $nav.toggleClass("scrolled");
-            $text.toggleClass("dark");
+            $nav.toggleClass('scrolled');
+            $text.toggleClass('dark');
         }
     });
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,16 +1,16 @@
 $(function() {
-  $(document).scroll(function() {
-    var $nav = $('.fixed-top')
-    $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height())
-    var $text = $('.text-white')
-    $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
-  })
-  $('.navbar-toggler').click(() => {
-    var $nav = $('.fixed-top')
-    var $text = $('.text-white')
-    if ($(this).scrollTop() < $nav.height()) {
-      $nav.toggleClass('scrolled')
-      $text.toggleClass('dark')
-    }
-  })
+    $(document).scroll(function() {
+        var $nav = $('.fixed-top')
+        $nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height())
+        var $text = $('.text-white')
+        $text.toggleClass('dark', $(this).scrollTop() > $nav.height())
+    })
+    $('.navbar-toggler').click(() => {
+        var $nav = $('.fixed-top')
+        var $text = $('.text-white')
+        if ($(this).scrollTop() < $nav.height()) {
+            $nav.toggleClass('scrolled')
+            $text.toggleClass('dark')
+        }
+    })
 })


### PR DESCRIPTION
# Changed navbar color on toggle
**header is transpatent when opened at top of page makes it difficult to view menu.**
> this commit fixes the issue.

Main changes:
- click handler added to .nav-toggler to toggle scorlled and dark classes on $nav and $text when color of header is transparent to make menu readable and consistent with UI.

Other changes:
- indentation used 2 spaces.
- all CSS selectors end with the new line, if comma seperated newline after each comma.
- moved transition property from .fixed-top.scrolled to .fixed-top for to add transition to both open and close of menu.
- 80 character wordwrap.